### PR TITLE
Added Hawser

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The Lanyard community has worked on some pretty cool projects that allows you to
 [react-use-lanyard](https://github.com/barbarbar338/react-use-lanyard) - React hook for Lanyard - supports REST & WebSocket  
 [use-lanyard](https://github.com/alii/use-lanyard) - Another React hook for Lanyard that uses SWR  
 [lanyard-visualizer](https://lanyard-visualizer.netlify.app/) - Beautifully display your Discord presence on a website
+[hawser](https://github.com/5elenay/hawser) - Lanyard API wrapper for python. Supports both REST and WebSocket.  
 
 ## API Docs
 


### PR DESCRIPTION
Hawser is Lanyard API wrapper for Python. Supports both REST and WebSocket Methods. 
Links: [PyPi](https://pypi.org/project/hawser/) | [GitHub](https://github.com/5elenay/hawser)
Edit: Typo