### PR TITLE
Added anaxes.xyz to lanyard use list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Below is a list of sites using Lanyard right now, check them out! A lot of them 
 - [nickdev.org](https://nickdev.org)
 - [encrypteddev.com](https://encrypteddev.com)
 - [kevinthomas.codes](https://kevinthomas.codes)
+- [anaxes.xyz](https://anaxes.xyz)
 
 ## Todo
 


### PR DESCRIPTION
Added [anaxes.xyz](https://anaxes.xyz) to the websites using lanyard list.

Proof: 

<img src="https://cdn.tixte.com/uploads/cdn.anaxes.xyz/kqhwrvtq09a.png"/>

Please note: The "listening to" section only appears when I am listening to Spotify. The "status" icon located next to the header title, appears all the time and updates accordingly. 
