### PR TITLE
Added maisakurajima.netlify.app to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Below is a list of sites using Lanyard right now, check them out! A lot of them 
 - [loom4k.me](https://loom4k.me)
 - [katsie.xyz](https://katsie.xyz)
 - [presence.im](https://presence.im/)
+- [maisakurajima.netlify.app](https://maisakurajima.netlify.app/)
 
 ## Todo
 


### PR DESCRIPTION
This PR adds the website maisakurajima.netlify.app to the Readme File.
It uses Lanyard to pull the data on the [`/team`](https://maisakurajima.netlify.app/team) page.