### PR TITLE
Added "Anaxes.xyz" to 'used by' list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Below is a list of sites using Lanyard right now, check them out! A lot of them 
 - [mehmetali345.xyz](https://mehmetali345.xyz)
 - [jackbailey.uk](https://jackbailey.uk)
 - [d3r1n.com](https://d3r1n.com/)
+- [anaxes.xyz](https://anaxes.xyz)
 
 
 ## Todo


### PR DESCRIPTION
Adding back my website as I am unsure as to why it was removed. 

Proof of Lanyard's REST API being used within my website:

<details>
  <summary>🚀 Activity Card towards the bottom of my website</summary> 
  <img src="https://us-east-1.tixte.net/uploads/cdn.anaxes.xyz/ktw8nrdxs9a.png"/>
</details>

<details>
  <summary>🌏 Small status' at top of the page.</summary> 
  <img src="https://us-east-1.tixte.net/uploads/cdn.anaxes.xyz/ktw8r9ygm9a.png"/>
</details>