### PR TITLE
Add Docker support for self hosting

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,31 @@
+Dockerfile
+
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+lanyard-*.tar
+
+# Temporary files for e.g. tests
+/tmp
+
+# VSCode Elixir LS Extension
+.elixir_ls/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM elixir:1.12.3-alpine AS build
+
+ENV MIX_ENV=prod
+
+WORKDIR /app
+
+# get deps first so we have a cache
+ADD mix.exs mix.lock /app/
+RUN \
+cd /app && \
+mix local.hex --force && \
+mix local.rebar --force && \
+mix deps.get
+
+# then make a release build
+ADD . /app/
+RUN \
+mix compile && \
+mix release
+
+FROM elixir:1.12.3-alpine
+
+COPY --from=build /app/_build/prod/rel/lanyard /opt/lanyard
+
+CMD [ "/opt/lanyard/bin/lanyard", "start" ]

--- a/README.md
+++ b/README.md
@@ -199,6 +199,47 @@ Lanyard can disconnect clients for multiple reasons, usually to do with messages
 | ---------------------- | ---- | ---------------- |
 | Invalid/Unknown Opcode | 4004 | `unknown_opcode` |
 
+## Self-host with Docker
+
+Build the Docker image by cloning this repo and running:
+
+```bash
+docker build -t lanyard/lanyard:latest .
+```
+
+And run Lanyard API server using:
+
+```bash
+docker run --rm -it -p 4001:4001 -e BOT_TOKEN=<token> lanyard/lanyard:latest
+```
+
+You'll be able to access the API using **port 4001**.
+
+You also need to create a Discord bot and use its token above.
+
+Create a bot here: https://discord.com/developers/applications
+
+**Make sure you enable** these settings in your bot settings:
+
+-   Privileged Gateway Intents > **PRESENCE INTENT**
+-   Privileged Gateway Intents > **SERVER MEMBERS INTENT**
+
+If you'd like to run Lanyard with `docker-compose`, here's an example:
+
+```yml
+version: "3.8"
+services:
+    lanyard:
+        image: lanyard/lanyard:latest
+        restart: always
+        ports:
+            - 4001:4001
+        environment:
+            BOT_TOKEN: <token>
+```
+
+Note, that you're **hosting a http server, not https**. You'll need to use a **reverse proxy** such as [traefik](https://traefik.io/traefik/) if you want to secure your API endpoint.
+
 ## Used By
 
 Below is a list of sites using Lanyard right now, check them out! A lot of them will only show an activity when they're active. Create a PR to add your site below!

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,4 @@
+use Mix.Config
+
+config :lanyard,
+  bot_token: System.get_env("BOT_TOKEN")

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,0 +1,6 @@
+import Config
+
+if config_env() == :prod do
+  config :lanyard,
+    bot_token: System.get_env("BOT_TOKEN")
+end


### PR DESCRIPTION
I added Docker support! I've written some instructions in the readme. I'm not very familiar with elixir but I figured I had to create a `runtime.exs` so it would load `BOT_TOKEN` on runtime. I found more about that here: https://fly.io/docs/getting-started/elixir/#runtime-config

The final image is about 92 MB which is great for a Docker image. I'm not sure if you're familiar with publishing to Docker hub, but I'm happy to help. I use Docker daily and I'll gladly make a github actions pipeline if you'd like.

Finally, thank you for making this! I really love Lanyard.

I have it self hosted here: https://lanyard.cutelab.space
Which my site is using, reducing some load: https://maki.cafe