### PR TITLE
Changing dustin.sh to dstn.to

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Below is a list of sites using Lanyard right now, check them out! A lot of them 
 
 - [alistair.cloud](https://alistair.cloud)
 - [timcole.me](https://timcole.me)
-- [dustin.sh](https://dustin.sh)
+- [dstn.to](https://dstn.to)
 - [phineas.io](https://phineas.io)
 - [slayter.dev](https://slayter.dev)
 - [lafond.dev](https://lafond.dev)


### PR DESCRIPTION
Changed the main domain of my site to dstn.to so I figured I'd change here to so it's not just a redirect.