### PR TITLE
Adding hint that you can skip the build step

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,8 +3,6 @@ name: Docker Image CI
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Lanyard can disconnect clients for multiple reasons, usually to do with messages
 Build the Docker image by cloning this repo and running:
 
 ```bash
+# The latest version is already on the docker hub, you can skip this step unless you would like to run a modified version.
 docker build -t phineas/lanyard:latest .
 ```
 


### PR DESCRIPTION
Meant to get this in the last PR, but was merged right before I pushed it.

It's obviously not required to build the docker image if you want to run the same version as production, so adding a hint to make that clear.

Also changes workflow to only run on main branch push