### PR TITLE
Updated Docker on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,18 +285,21 @@ If you'd like to run Lanyard with `docker-compose`, here's an example:
 version: "3.8"
 
 services:
+  redis:
+    image: redis
+    restart: always
+    container_name: lanyard_redis
   lanyard:
     image: phineas/lanyard:latest
     restart: always
     container_name: lanyard
+    depends_on:
+      - redis
     ports:
       - 4001:4001
     environment:
       BOT_TOKEN: <token>
       REDIS_HOST: redis
-  redis:
-    image: redis
-    container_name: lanyard_redis
 ```
 
 Note, that you're **hosting a http server, not https**. You'll need to use a **reverse proxy** such as [traefik](https://traefik.io/traefik/) if you want to secure your API endpoint.


### PR DESCRIPTION
I added `restart: always` and `depends_on: redis`. I also moved redis up since its a dependency on lanyard. Thank you so much for updating the read me. My instance broke on my server and was able to immediately fix it.