### PR TITLE
fix example api response in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Example response:
           "large_text": "Editing a MARKDOWN file",
           "large_image": "565945077491433494"
         },
-        "application_id": 383226320970055681
+        "application_id": "383226320970055681"
       }
     ]
   }


### PR DESCRIPTION
`application_id` is a `string`, not a `number`