### PR TITLE
Pipe docker password instead of using it as an argument

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,7 +17,7 @@ jobs:
           DOCKER_USERNAME: ${{secrets.DOCKER_USERNAME}}
           DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
         run: |
-          docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+          echo "$DOCKER_PASSWORD" | docker login -u $DOCKER_USERNAME --password-stdin
       - name: Build the Docker image
         run: docker build . --file Dockerfile --tag phineas/lanyard:latest
       - name: Docker Push


### PR DESCRIPTION
Passing DOCKER_PASSWORD via stdin is more secure, since arguments are visible in the process tree.

It might not make a difference, but passing data through stdin involves passing it through a file descriptor which can be read by using standard io calls. Command line arguments are kept in a processes `argv` in memory, any unprivileged can access that address of memory to view the arguments.