### PR TITLE
Add sudokoko.xyz to used by

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,7 @@ Below is a list of sites using Lanyard right now, check them out! A lot of them 
 - [afn.lol](https://afn.lol)
 - [ushie.dev](https://ushie.dev)
 - [lonelil.dev](https://lonelil.dev)
+- [sudokoko.xyz](https://sudokoko.xyz)
 
 ## Todo
 


### PR DESCRIPTION
Adds my personal site to the used by list.

Backend code for pulling and displaying Rich Presence can be found here: https://github.com/sudokoko/PersonalSite/blob/master/PersonalSite/Pages/Home.cshtml.cs