### PR TITLE
Prevent crash with Spotify local files

### DIFF
--- a/lib/presence/spotify.ex
+++ b/lib/presence/spotify.ex
@@ -1,8 +1,14 @@
 defmodule Lanyard.Presence.Spotify do
   def build_pretty_spotify(activity) when is_map(activity) do
+    artist =
+      case Map.fetch(activity, :state) do
+        {:ok, state} -> state
+        :error -> nil
+      end
+
     %{
       track_id: get_track_id(activity),
-      artist: activity.state,
+      artist: artist,
       song: activity.details,
       album: get_album_title(activity),
       album_art_url: get_album_art_url(activity),

--- a/lib/presence/spotify.ex
+++ b/lib/presence/spotify.ex
@@ -1,14 +1,8 @@
 defmodule Lanyard.Presence.Spotify do
   def build_pretty_spotify(activity) when is_map(activity) do
-    artist =
-      case Map.fetch(activity, :state) do
-        {:ok, state} -> state
-        :error -> nil
-      end
-
     %{
       track_id: get_track_id(activity),
-      artist: artist,
+      artist: Map.get(activity, :state),
       song: activity.details,
       album: get_album_title(activity),
       album_art_url: get_album_art_url(activity),


### PR DESCRIPTION
`spotify_activity` has no `state` if the user is listening to a local file, resulting in a crash.  
This PR changes build_pretty_spotify to ensure the spotify activity has `state`, even if there's no data  
This will prevent lanyard from freezing for a while whenever you play a local file.  

Here's an example of the error that was occuring:

```
21:23:08.744 [error] GenServer :"presence:303267459824353280" terminating
** (KeyError) key :state not found in: %{id: "spotify:1", name: "Spotify", type: 2, details: "EMPTY DIARY (instrumental)", timestamps: %{start: 1715635386950, end: 1715635586950}, assets: %{large_text: "UNBEATABLE: DEMO TAPES"}, created_at: 1715635388913, party: %{id: "spotify:303267459824353280"}}
    (lanyard 0.1.0) lib/presence/spotify.ex:5: Lanyard.Presence.Spotify.build_pretty_spotify/1
    (lanyard 0.1.0) lib/presence/presence.ex:197: Lanyard.Presence.build_pretty_presence/1
    (lanyard 0.1.0) lib/presence/presence.ex:105: Lanyard.Presence.handle_cast/2
    (stdlib 5.2.3) gen_server.erl:1121: :gen_server.try_handle_cast/3
    (stdlib 5.2.3) gen_server.erl:1183: :gen_server.handle_msg/6
    (stdlib 5.2.3) proc_lib.erl:241: :proc_lib.init_p_do_apply/3
Last message: {:"$gen_cast", {:sync, %{discord_presence: %{status: :online, user: %{id: 303267459824353280}, broadcast: nil, activities: [%{id: "spotify:1", name: "Spotify", type: 2, details: "EMPTY DIARY (instrumental)", timestamps: %{start: 1715635386950, end: 1715635586950}, assets: %{large_text: "UNBEATABLE: DEMO TAPES"}, created_at: 1715635388913, party: %{id: "spotify:303267459824353280"}}], guild_id: 705114283683610988, client_status: %{desktop: :online}}}}}
State: %Lanyard.Presence{user_id: "303267459824353280", discord_user: %{id: 303267459824353280, username: "iamasink", avatar: "c97773d8ea60932eef12331d41effeca", discriminator: "0", bot: false, clan: nil, global_name: "lillie", avatar_decoration_data: nil, display_name: "lillie", public_flags: 128}, discord_presence: %{status: :online, user: %{id: 303267459824353280}, broadcast: nil, activities: [%{flags: 48, id: "spotify:1", name: "Spotify", type: 2, state: "水槽", session_id: "b05c49cbec04113d63ddffa38727e577", details: "p.h. - cover", timestamps: %{start: 1715635370901, end: 1715635523830}, assets: %{large_image: "spotify:ab67616d0000b2736f4be5c667dfbf2c2781c4c9", large_text: "p.h. (cover)"}, sync_id: "3rWyLf6o3RMbUeK4aafkHd", created_at: 1715635372945, party: %{id: "spotify:303267459824353280"}}], guild_id: 1008017419043872849, client_status: %{desktop: :online}}, kv: %{}, subscriber_pids: [], refmap: %{}}
```
I haven't any experience with Elixir so sorry if anything is wrong, but it seems to work fine ^^