### PR TITLE
Added iStatus into Community Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The Lanyard community has worked on some pretty cool projects that allows you to
 [osu-nowplaying](https://github.com/Hexality/osu-nowplaying) - A small tool to scrape the info of the map you're curently playing on osu!lazer and dump into a file for obs to read. \
 [lanyard.py](https://github.com/sawshadev/lanyard-py) - An asynchronous implementation of the Lanyard websocket and HTTP for python \
 [landart](https://pub.dev/packages/landart) - A featureful API wrapper for Lanyard & Lanyard KV written in Dart.
-[iStatus](https://lanyard-istatus.vercel.app/docs#/) - A Lanyard API for Github profiles and CSS + HTML.
+[iStatus](https://lanyard-istatus.vercel.app/) - A Lanyard API for Github profiles and CSS + HTML.
 
 ## API Docs
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The Lanyard community has worked on some pretty cool projects that allows you to
 [osu-nowplaying](https://github.com/Hexality/osu-nowplaying) - A small tool to scrape the info of the map you're curently playing on osu!lazer and dump into a file for obs to read. \
 [lanyard.py](https://github.com/sawshadev/lanyard-py) - An asynchronous implementation of the Lanyard websocket and HTTP for python \
 [landart](https://pub.dev/packages/landart) - A featureful API wrapper for Lanyard & Lanyard KV written in Dart.
+[iStatus](https://lanyard-istatus.vercel.app/docs#/) - A Lanyard API for Github profiles and CSS + HTML.
 
 ## API Docs
 


### PR DESCRIPTION
Hey! I've created this new thing called **iStatus** which allows you to use Lanyard; however, you can make this more useful by putting your current status in your GitHub profile.

Example code for your status.
```html
 <img src="https://lanyard-istatus.vercel.app/user_status/:id" height="30" width="75">
 <!-- Replace :id with your id! -->
```