### PR TITLE
Default to jpg over gif on quicklinks when not animated

### DIFF
--- a/lib/api/routes/quicklinks/discord_cdn.ex
+++ b/lib/api/routes/quicklinks/discord_cdn.ex
@@ -36,6 +36,13 @@ defmodule Lanyard.Api.Quicklinks.DiscordCdn do
   end
 
   defp get_proxied_avatar(id, avatar, _discriminator, file_type) when is_binary(avatar) do
+    file_type =
+      if !String.starts_with?(avatar, "a_") && file_type == "gif" do
+        "jpg"
+      else
+        file_type
+      end
+
     constructed_cdn_url = "#{@discord_cdn}/avatars/#{id}/#{avatar}.#{file_type}?size=1024"
 
     :get


### PR DESCRIPTION
If the avatar doesn't begin with a_ it's not animated so when .gif is requested it will fail, this PR defaults the request to use .jpg in that case so that it doesn't fail.