### PR TITLE
Highlight "heartbeat_interval" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ The user's KV store will be merged with the body of the request. Conflicting key
 
 The websocket is available at `wss://api.lanyard.rest/socket`. If you would like to use compression, please specify `?compression=zlib_json` at the end of the URL.
 
-Once connected, you will receive Opcode 1: Hello which will contain heartbeat_interval in the data field. You should set a repeating interval for the time specified in heartbeat_interval which should send Opcode 3: Heartbeat on the interval.
+Once connected, you will receive Opcode 1: Hello which will contain `heartbeat_interval` in the data field. You should set a repeating interval for the time specified in heartbeat_interval which should send Opcode 3: Heartbeat on the interval.
 
 You should send `Opcode 2: Initialize` immediately after receiving Opcode 1.
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ The user's KV store will be merged with the body of the request. Conflicting key
 
 The websocket is available at `wss://api.lanyard.rest/socket`. If you would like to use compression, please specify `?compression=zlib_json` at the end of the URL.
 
-Once connected, you will receive Opcode 1: Hello which will contain `heartbeat_interval` in the data field. You should set a repeating interval for the time specified in heartbeat_interval which should send Opcode 3: Heartbeat on the interval.
+Once connected, you will receive Opcode 1: Hello which will contain `heartbeat_interval` in the data field. You should set a repeating interval for the time specified in `heartbeat_interval` which should send Opcode 3: Heartbeat on the interval.
 
 You should send `Opcode 2: Initialize` immediately after receiving Opcode 1.
 


### PR DESCRIPTION
Hi!

This isn't a major change by any means however when getting started, I struggled to find one of the required fields for a Websocket connection. 
I was expecting it to be highlighted somewhere considering its quite important for the entire Websocket connection workflow, but I found it buried somewhere in the middle of a text.

This PR just adds a visual highlight to the README to ensure that the required `heartbeat_interval` variable can be found just by quickly skimming through the texts.

Cheers! :D