### PR TITLE
Throw 400 on failed Upgrade by the request.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@
 /.fetch
 
 # If the VM crashes, it generates a dump, let's ignore it too.
-erl_crash.dump
+erl_crash.dump*
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez

--- a/lib/api/router.ex
+++ b/lib/api/router.ex
@@ -52,11 +52,22 @@ defmodule Lanyard.Api.Router do
   end
 
   get "/socket" do
-    conn = %Plug.Conn{query_params: params} = fetch_query_params(conn)
+    %Plug.Conn{query_params: params} = fetch_query_params(conn)
 
-    conn
-    |> WebSockAdapter.upgrade(Lanyard.SocketHandler, params, timeout: 60_000)
-    |> halt()
+    try do
+      conn
+      |> WebSockAdapter.upgrade(Lanyard.SocketHandler, params, timeout: 60_000)
+      |> halt()
+    rescue
+      WebSockAdapter.UpgradeError ->
+        conn
+        |> Util.respond({:error, 400, :upgrade_failed, "Request failed to upgrade"})
+        |> halt()
+
+      # i would image this is effectively useless as only the Upgrade could throw
+      other ->
+        reraise other, __STACKTRACE__
+    end
   end
 
   forward("/v1", to: V1)


### PR DESCRIPTION
`WebSockAdapter.upgrade` for some reasons can error, however it uses the `WebSockAdapter.UpgradeValidation.validate_upgrade!` function that raises an exception of `WebSockAdapter.UpgradeError`

Pretty annoying, I might say.