### PR TITLE
Fix IO.inspect leak, activity key mismatch, and GenServer state corruption in presence sync

### DIFF
--- a/lib/presence/activity.ex
+++ b/lib/presence/activity.ex
@@ -3,23 +3,24 @@ defmodule Lanyard.Presence.Activity do
     activities
     |> Enum.map(fn activity ->
       activity
-      |> decorate_app_id
-      |> decorate_emoji
+      |> decorate_app_id()
+      |> decorate_emoji()
     end)
   end
 
-  defp decorate_app_id(%{application_id: application_id} = activity)
+  defp decorate_app_id(%{"application_id" => application_id} = activity)
        when not is_binary(application_id),
-       do: %{activity | application_id: "#{application_id}"}
+       do: Map.put(activity, "application_id", "#{application_id}")
 
   defp decorate_app_id(activity), do: activity
 
-  defp decorate_emoji(%{emoji: %{id: emoji_id} = emoji} = activity) when is_number(emoji_id),
-    do: %{activity | emoji: %{emoji | id: "#{emoji_id}"}}
+  defp decorate_emoji(%{"emoji" => %{"id" => emoji_id} = emoji} = activity)
+       when is_number(emoji_id),
+       do: Map.put(activity, "emoji", Map.put(emoji, "id", "#{emoji_id}"))
 
-  defp decorate_emoji(%{emoji: %{name: emoji_name} = emoji} = activity)
+  defp decorate_emoji(%{"emoji" => %{"name" => emoji_name} = emoji} = activity)
        when is_binary(emoji_name),
-       do: %{activity | emoji: emoji}
+       do: Map.put(activity, "emoji", emoji)
 
   defp decorate_emoji(activity), do: activity
 end

--- a/lib/presence/presence.ex
+++ b/lib/presence/presence.ex
@@ -20,6 +20,7 @@ end
 
 defmodule Lanyard.Presence do
   use GenServer
+  require Logger
 
   alias Lanyard.Connectivity.Redis
   alias Lanyard.Presence.Spotify
@@ -114,16 +115,18 @@ defmodule Lanyard.Presence do
         {key, v}
       end
 
+    merged_state =
+      %{
+        discord_user: state.discord_user,
+        discord_presence: state.discord_presence,
+        user_id: state.user_id,
+        kv: state.kv
+      }
+      |> Map.merge(normalized_new_state)
+
     {_, pretty_presence} =
-      get_public_fields(
-        %{
-          discord_user: state.discord_user,
-          discord_presence: state.discord_presence,
-          user_id: state.user_id,
-          kv: state.kv
-        }
-        |> Map.merge(normalized_new_state)
-      )
+      merged_state
+      |> get_public_fields()
       |> build_pretty_presence()
 
     Manifold.send(
@@ -131,7 +134,7 @@ defmodule Lanyard.Presence do
       {:remote_send, %{op: 0, t: "PRESENCE_UPDATE", d: pretty_presence}}
     )
 
-    {:noreply, Map.merge(state, new_state)}
+    {:noreply, Map.merge(state, normalized_new_state)}
   end
 
   @spec get_public_fields(map()) :: %Lanyard.Presence.PublicFields{}
@@ -251,7 +254,7 @@ defmodule Lanyard.Presence do
     with {:ok, pid} <-
            GenRegistry.lookup(__MODULE__, user_id) do
       GenServer.cast(pid, {:sync, payload})
-      IO.inspect("Syncing presence for user #{user_id}")
+      Logger.debug("Syncing presence for user #{user_id}")
 
       unless from_global_sync do
         Task.start(fn ->


### PR DESCRIPTION
Three bugs in the presence sync path.

**IO.inspect in production (presence.ex)**
`sync/3` calls `IO.inspect` on every presence update, bypassing Logger entirely. Replaced with `Logger.debug`.

**Activity decoration never ran (activity.ex)**
`decorate_app_id` and `decorate_emoji` pattern-matched on atom keys. Discord payloads have string keys, so the matches never fired. `application_id` was left as a raw integer in API responses, Discord Snowflake IDs are 64-bit and exceed `Number.MAX_SAFE_INTEGER`, corrupting JS clients. Emoji fields were also never normalized. Fixed by switching to string key matches.

**GenServer state corrupted on sync (presence.ex)**
`handle_cast` merged the raw Discord payload (string keys) directly into the GenServer struct (atom keys). `Map.merge` doesn't unify key types, so the state ended up holding both `:discord_presence` and `"discord_presence"`, with reads using the stale atom-keyed value. Fixed by merging the already-normalized map instead of the raw payload.