### PR TITLE
Update venqoi.love to venqoi.lol after experation

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ Below is a curated selection of websites using Lanyard right now, check them out
 - [makidoll.io](https://makidoll.io/)
 - [dan.onl](https://dan.onl/)
 - [cnrad.dev](https://cnrad.dev)
-- [venqoi.love](https://venqoi.love/)
+- [venqoi.lol](https://venqoi.lol/)
 - [phineas.io](https://phineas.io)
 - [timcole.me](https://timcole.me)
 - [itspolar.dev](https://itspolar.dev)


### PR DESCRIPTION
My domain has once again expired so I'm back to venqoi.lol, thank you Dustin.