### PR TITLE
fix: handle other disconnect reasons and log them

### DIFF
--- a/lib/gateway/client.ex
+++ b/lib/gateway/client.ex
@@ -75,8 +75,10 @@ defmodule Lanyard.Gateway.Client do
     {:ok, state}
   end
 
-  def ondisconnect({:remote, :closed}, state) do
-    Logger.warning("Discord: Remote closed connection, will attempt resume")
+  def ondisconnect(reason, state) do
+    Logger.warning(
+      "Discord: WebSocket disconnected with reason #{inspect(reason)}, will attempt resume"
+    )
 
     if state[:session_id] && state[:resume_gateway_url] do
       seq_num = agent_value(state[:agent_seq_num])
@@ -92,7 +94,7 @@ defmodule Lanyard.Gateway.Client do
       )
     end
 
-    {:close, {:remote, :closed}, state}
+    {:close, reason, state}
   end
 
   def websocket_handle({:text, payload}, _socket, state) do
@@ -227,13 +229,17 @@ defmodule Lanyard.Gateway.Client do
 
     Logger.info("Websocket closed in state #{inspect(state)} with reason #{inspect(reason)}")
     Logger.info("Killing seq_num process!")
-    Process.exit(state[:agent_seq_num], :kill)
+    kill_process(state[:agent_seq_num])
     Logger.info("Killing rest_client process!")
-    Process.exit(state[:rest_client], :kill)
+    kill_process(state[:rest_client])
     Logger.info("Killing heartbeat process!")
-    Process.exit(state[:heartbeat_pid], :kill)
+    kill_process(state[:heartbeat_pid])
     :ok
   end
+
+  # we can term before any of the sub processes are started: gateway fails to connect etc
+  defp kill_process(pid) when is_pid(pid), do: Process.exit(pid, :kill)
+  defp kill_process(_pid), do: :ok
 
   def handle_event({:ready, payload}, state) do
     new_state =

--- a/lib/gateway/client.ex
+++ b/lib/gateway/client.ex
@@ -77,7 +77,7 @@ defmodule Lanyard.Gateway.Client do
 
   def ondisconnect(reason, state) do
     Logger.warning(
-      "Discord: WebSocket disconnected with reason #{inspect(reason)}, will attempt resume"
+      "Discord: Websocket disconnected with reason #{inspect(reason)}, will attempt resume"
     )
 
     if state[:session_id] && state[:resume_gateway_url] do
@@ -227,19 +227,10 @@ defmodule Lanyard.Gateway.Client do
   def websocket_terminate(reason, _conn_state, state) do
     Lanyard.Metrics.Collector.set(:gauge, :lanyard_monitored_users, 0)
 
-    Logger.info("Websocket closed in state #{inspect(state)} with reason #{inspect(reason)}")
-    Logger.info("Killing seq_num process!")
-    kill_process(state[:agent_seq_num])
-    Logger.info("Killing rest_client process!")
-    kill_process(state[:rest_client])
-    Logger.info("Killing heartbeat process!")
-    kill_process(state[:heartbeat_pid])
+    Logger.info("Discord: Websocket closed in state #{inspect(state)} with reason #{inspect(reason)}")
+
     :ok
   end
-
-  # we can term before any of the sub processes are started: gateway fails to connect etc
-  defp kill_process(pid) when is_pid(pid), do: Process.exit(pid, :kill)
-  defp kill_process(_pid), do: :ok
 
   def handle_event({:ready, payload}, state) do
     new_state =


### PR DESCRIPTION
I checked the source code of `websocket_client`, and it can [throw more errors](https://github.com/sanmiguel/websocket_client/blob/cf396d23fc067d0a34ee00cfdf73d9122733dca8/src/websocket_client.erl#L55-L64):
```erl
% Called when the socket is closed for any reason.
-callback ondisconnect(reason(), state()) ->
    % Return to `disconnected` state but keep process alive.
    {ok, state()}
    % Immediately attempt to reconnect.
    | {reconnect, state()}
    % Reconnect after interval.
    | {reconnect, non_neg_integer(), state()}
    % Shut the process down cleanly.
    | {close, reason(), state()}.
```

Which would be fine but it can actually throw a couple more via this: https://github.com/sanmiguel/websocket_client/blob/cf396d23fc067d0a34ee00cfdf73d9122733dca8/src/websocket_client.erl#L275-L293 (which is basically `ssl:connect()` for lanyard)
and also the old `{:remote, :closed}` which is also not defined above....

I also removed the manual process kills, they were pretty useless as any close event kills the process and removed the linked (`start_link`) processes.

---

btw: I guess longer term we should replace this lib anyway, because from what I read in tesla docs, ssl is insecure, and they themselves recommend mint or other http clients.