### PR TITLE
normalize auth headers and presence sync state

### DIFF
--- a/lib/api/routes/v1/users.ex
+++ b/lib/api/routes/v1/users.ex
@@ -9,7 +9,7 @@ defmodule Lanyard.Api.Routes.V1.Users do
   plug(:dispatch)
 
   get "/@me" do
-    key = conn |> Plug.Conn.get_req_header("authorization")
+    key = Util.authorization_header(conn)
 
     case Redis.get("api_key:#{key}") do
       user_id when is_binary(user_id) ->
@@ -96,7 +96,7 @@ defmodule Lanyard.Api.Routes.V1.Users do
 
   defp validate_resource_access(conn) do
     %Plug.Conn{params: %{"id" => user_id}} = conn
-    key = conn |> Plug.Conn.get_req_header("authorization")
+    key = Util.authorization_header(conn)
 
     case Redis.get("api_key:#{key}") do
       ^user_id ->

--- a/lib/api/util.ex
+++ b/lib/api/util.ex
@@ -8,6 +8,13 @@ defmodule Lanyard.Api.Util do
     |> send_resp(:found, url)
   end
 
+  @spec authorization_header(Plug.Conn.t()) :: binary | nil
+  def authorization_header(conn) do
+    conn
+    |> get_req_header("authorization")
+    |> List.first()
+  end
+
   @spec respond(Plug.Conn.t(), {:ok}) :: Plug.Conn.t()
   def respond(conn, {:ok}) do
     conn

--- a/lib/presence/presence.ex
+++ b/lib/presence/presence.ex
@@ -24,6 +24,7 @@ defmodule Lanyard.Presence do
   alias Lanyard.Connectivity.Redis
   alias Lanyard.Presence.Spotify
   alias Lanyard.Presence.Activity
+  require Logger
 
   @derive Jason.Encoder
   defstruct user_id: nil,
@@ -131,7 +132,7 @@ defmodule Lanyard.Presence do
       {:remote_send, %{op: 0, t: "PRESENCE_UPDATE", d: pretty_presence}}
     )
 
-    {:noreply, Map.merge(state, new_state)}
+    {:noreply, Map.merge(state, normalized_new_state)}
   end
 
   @spec get_public_fields(map()) :: %Lanyard.Presence.PublicFields{}
@@ -251,7 +252,7 @@ defmodule Lanyard.Presence do
     with {:ok, pid} <-
            GenRegistry.lookup(__MODULE__, user_id) do
       GenServer.cast(pid, {:sync, payload})
-      IO.inspect("Syncing presence for user #{user_id}")
+      Logger.debug("Syncing presence for user #{user_id}")
 
       unless from_global_sync do
         Task.start(fn ->


### PR DESCRIPTION
# Changes
- Read the first `authorization` header value before checking the API key in Redis
- Merge the normalized presence sync payload back into the GenServer state
- Changed a debug `IO.inspect` to `Logger.debug`
# Why
- `get_req_header` returns a list, so the API key check should use the actual header value instead of the whole list

- The presence sync code already normalized incoming payload keys for the update it sends out, but it was still saving the original payload into state. Saving the normalized payload keeps the stored state consistent too

- `Logger.debug` is better than `IO.inspect` here because it respects the app’s logging config

# Testing
I tried running locally but my network timed out multiple times when installing the dependencies.
Very sad, can you test it locally plss I'm sure it would work right