### PR TITLE
docs: remove redirecting showcase link makidoll.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,6 @@ Below is a curated selection of websites using Lanyard right now, check them out
 - [igalaxy.dev](https://igalaxy.dev)
 - [anahoward.me](https://www.anahoward.me/)
 - [chezzer.dev](https://chezzer.dev)
-- [makidoll.io](https://makidoll.io/)
 - [dan.onl](https://dan.onl/)
 - [cnrad.dev](https://cnrad.dev)
 - [venqoi.lol](https://venqoi.lol/)


### PR DESCRIPTION
The link does not seem to contain the intended content anymore:
<img width="1816" height="1170" alt="image" src="https://github.com/user-attachments/assets/a5752349-9aa3-40c0-8f83-bcbb1c814b1d" />
