### PR TITLE
Include user ID in presence updates

### DIFF
--- a/lib/presence/presence.ex
+++ b/lib/presence/presence.ex
@@ -5,7 +5,8 @@ end
 
 defmodule Lanyard.Presence.PrettyPresence do
   @derive Jason.Encoder
-  defstruct discord_user: %{},
+  defstruct user_id: nil,
+            discord_user: %{},
             discord_status: "offline",
             active_on_discord_web: false,
             active_on_discord_desktop: false,
@@ -202,6 +203,7 @@ defmodule Lanyard.Presence do
     pretty_fields =
       if has_presence? do
         %Lanyard.Presence.PrettyPresence{
+          user_id: raw_data.user_id,
           discord_user: raw_data.discord_user,
           discord_status: raw_data.discord_presence["status"],
           active_on_discord_web: Map.has_key?(raw_data.discord_presence["client_status"], "web"),
@@ -219,6 +221,7 @@ defmodule Lanyard.Presence do
         }
       else
         %Lanyard.Presence.PrettyPresence{
+          user_id: raw_data.user_id,
           discord_user: raw_data.discord_user,
           kv: raw_data.kv
         }


### PR DESCRIPTION
The README claims that presence updates include an extra userid field,
<img width="793" height="394" alt="Screenshot_20260707-010457" src="https://github.com/user-attachments/assets/c735bbb0-2bf0-412f-8d6d-e4db38b798f1" />
however in presence.ex the pretty presence class doesn't include a `user_id` entry, so later the code sends the broken update payload and `build_pretty_presence` builds without the promised extra `user_id` field

i added the field to pretty presence and some other parts of the code and uhh that's basically all i did 
tested locally and it should be working now
<img src="https://cdn.brookerslyn.space/1000024171-removebg-preview.png" width="30" height="40" alt="emoji"> <img src="https://cdn.brookerslyn.space/1000024171-removebg-preview.png" width="30" height="40" alt="emoji"> <img src="https://cdn.brookerslyn.space/1000024171-removebg-preview.png" width="30" height="40" alt="emoji">