### PR TITLE
Remove venqoi.lol link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,6 @@ Below is a curated selection of websites using Lanyard right now, check them out
 - [chezzer.dev](https://chezzer.dev)
 - [dan.onl](https://dan.onl/)
 - [cnrad.dev](https://cnrad.dev)
-- [venqoi.lol](https://venqoi.lol/)
 - [phineas.io](https://phineas.io)
 - [timcole.me](https://timcole.me)
 - [itspolar.dev](https://itspolar.dev)


### PR DESCRIPTION
Removed the link to venqoi.lol from the list due to venqoi not wanting to be associated with lanyard.

(in the image we are talking about lanyard.cafe however it still is correlated in a sense? also idk if i am allowed to add my own link so up to you dustin)

<img width="559" height="229" alt="image" src="https://github.com/user-attachments/assets/82f77d33-a752-46df-acf0-bd29fabc3ea3" />
