### PR TITLE
Clean up subscriber refs on disconnect

### DIFF
--- a/lib/presence/presence.ex
+++ b/lib/presence/presence.ex
@@ -71,7 +71,11 @@ defmodule Lanyard.Presence do
 
   def handle_info({:DOWN, _ref, :process, object, _reason}, state) do
     {:noreply,
-     %{state | subscriber_pids: state.subscriber_pids |> Enum.reject(fn sub -> sub == object end)}}
+     %{
+       state
+       | subscriber_pids: state.subscriber_pids |> Enum.reject(fn sub -> sub == object end),
+         refmap: Map.delete(state.refmap, object)
+     }}
   end
 
   def handle_info({:add_subscriber, pid}, state) do


### PR DESCRIPTION
tldr when you subscribe to an id, lanyard stores the PID's in both `subscriber_pids` and `refmap`, however when the connection is dropped, the code removes it from `subscriber_pids` but never `refmap`, which over time causes memory leaks and is just stale state


THIS CAN'T BE INTENTIONAL i swear, explicit unsubscribes drop `refmap` if this is intentional I'm gonna crash out