### PR TITLE
Clean up gateway lifecycle processes

### DIFF
--- a/lib/bot/discord_bot.ex
+++ b/lib/bot/discord_bot.ex
@@ -14,6 +14,8 @@ defmodule Lanyard.DiscordBot do
   end
 
   def init(state) do
+    # The gateway is both linked and monitored; trap exits so the :DOWN restart
+    # path below can run instead of losing the bot process first.
     Process.flag(:trap_exit, true)
 
     {:ok, %__MODULE__{token: state.token, gateway_client_pid: nil}, {:continue, :setup_bot}}

--- a/lib/bot/discord_bot.ex
+++ b/lib/bot/discord_bot.ex
@@ -14,6 +14,8 @@ defmodule Lanyard.DiscordBot do
   end
 
   def init(state) do
+    Process.flag(:trap_exit, true)
+
     {:ok, %__MODULE__{token: state.token, gateway_client_pid: nil}, {:continue, :setup_bot}}
   end
 
@@ -42,9 +44,21 @@ defmodule Lanyard.DiscordBot do
     {:noreply, %{state | resume_data: nil}}
   end
 
-  def handle_info({:DOWN, _ref, :process, _pid, reason}, state) do
-    Logger.warning("Discord bot crashed with reason: #{reason}. Restarting.")
+  def handle_info({:EXIT, pid, _reason}, %{gateway_client_pid: pid} = state) do
+    {:noreply, state}
+  end
+
+  def handle_info({:EXIT, _pid, _reason}, state) do
+    {:noreply, state}
+  end
+
+  def handle_info({:DOWN, _ref, :process, pid, reason}, %{gateway_client_pid: pid} = state) do
+    Logger.warning("Discord bot crashed with reason: #{inspect(reason)}. Restarting.")
 
     {:noreply, state, {:continue, :setup_bot}}
+  end
+
+  def handle_info({:DOWN, _ref, :process, _pid, _reason}, state) do
+    {:noreply, state}
   end
 end

--- a/lib/gateway/client.ex
+++ b/lib/gateway/client.ex
@@ -382,6 +382,8 @@ defmodule Lanyard.Gateway.Client do
   end
 
   defp cleanup_transient_processes(state) when is_map(state) do
+    # Reconnect/close paths can exit normally, which won't take linked helpers
+    # down with the gateway process.
     stop_process(state[:heartbeat_pid])
     stop_process(state[:agent_seq_num])
 

--- a/lib/gateway/client.ex
+++ b/lib/gateway/client.ex
@@ -94,7 +94,7 @@ defmodule Lanyard.Gateway.Client do
       )
     end
 
-    {:close, reason, state}
+    close_gateway(reason, state)
   end
 
   def websocket_handle({:text, payload}, _socket, state) do
@@ -121,6 +121,8 @@ defmodule Lanyard.Gateway.Client do
     # Discord sends hello op immediately after connection
     # Start sending heartbeat with interval defined by the hello packet
     Logger.debug("Discord: Hello")
+
+    stop_process(state[:heartbeat_pid])
 
     {:ok, heartbeat_pid} =
       Heartbeat.start_link(
@@ -169,13 +171,13 @@ defmodule Lanyard.Gateway.Client do
        }}
     )
 
-    {:close, "Reconnecting for resume", state}
+    close_gateway("Reconnecting for resume", state)
   end
 
   defp _handle_data(%{op: :invalid_session} = _data, state) do
     Logger.warning("Discord: Invalid session, starting new session")
     send(:discord_bot, :clear_resume)
-    {:close, "Invalid session, starting new session", state}
+    close_gateway("Invalid session, starting new session", state)
   end
 
   def websocket_info(:start, _connection, state) do
@@ -220,12 +222,16 @@ defmodule Lanyard.Gateway.Client do
        }}
     )
 
-    {:close, "Heartbeat stale", state}
+    close_gateway("Heartbeat stale", state)
   end
 
   @spec websocket_terminate(any(), any(), nil | keyword() | map()) :: :ok
   def websocket_terminate(reason, _conn_state, state) do
-    Logger.info("Discord: Websocket closed in state #{inspect(state)} with reason #{inspect(reason)}")
+    Logger.info(
+      "Discord: Websocket closed in state #{inspect(state)} with reason #{inspect(reason)}"
+    )
+
+    cleanup_transient_processes(state)
 
     :ok
   end
@@ -370,6 +376,33 @@ defmodule Lanyard.Gateway.Client do
       agent_update(state[:agent_seq_num], data.seq_num)
     end
   end
+
+  defp close_gateway(reason, state) do
+    {:close, reason, cleanup_transient_processes(state)}
+  end
+
+  defp cleanup_transient_processes(state) when is_map(state) do
+    stop_process(state[:heartbeat_pid])
+    stop_process(state[:agent_seq_num])
+
+    state
+    |> Map.put(:heartbeat_pid, nil)
+    |> Map.put(:agent_seq_num, nil)
+  end
+
+  defp cleanup_transient_processes(state), do: state
+
+  defp stop_process(pid) when is_pid(pid) do
+    if Process.alive?(pid) do
+      try do
+        GenServer.stop(pid, :normal, 1_000)
+      catch
+        :exit, _ -> :ok
+      end
+    end
+  end
+
+  defp stop_process(_pid), do: :ok
 
   defp create_member_presences(payload) do
     Task.start(fn ->

--- a/lib/gateway/heartbeat.ex
+++ b/lib/gateway/heartbeat.ex
@@ -21,6 +21,8 @@ defmodule Lanyard.Gateway.Heartbeat do
       agent_seq_num: agent_seq_num,
       interval: interval,
       socket_pid: socket_pid,
+      # Normal gateway exits do not stop linked processes, so tie heartbeat
+      # shutdown to the owning socket process explicitly.
       socket_ref: Process.monitor(socket_pid),
       timer: nil,
       ack?: true

--- a/lib/gateway/heartbeat.ex
+++ b/lib/gateway/heartbeat.ex
@@ -21,6 +21,7 @@ defmodule Lanyard.Gateway.Heartbeat do
       agent_seq_num: agent_seq_num,
       interval: interval,
       socket_pid: socket_pid,
+      socket_ref: Process.monitor(socket_pid),
       timer: nil,
       ack?: true
     }
@@ -40,6 +41,13 @@ defmodule Lanyard.Gateway.Heartbeat do
   def handle_info(:beat, %{socket_pid: socket_pid, ack?: false} = state) do
     send(socket_pid, :heartbeat_stale)
     {:noreply, %{state | timer: nil}}
+  end
+
+  def handle_info(
+        {:DOWN, ref, :process, pid, _reason},
+        %{socket_pid: pid, socket_ref: ref} = state
+      ) do
+    {:stop, :normal, state}
   end
 
   def handle_call(:ack, _from, state) do


### PR DESCRIPTION
discordbot was starting the gateway with `start_link` and also monitoring it, which meant an abnormal gateway exit could kill the bot before the existing `:DOWN` handler got a chance to restart/resume it

for example, if the discord websocket drops and the gateway exits with something like `{:remote, :closed}`, the existing monitor/restart path could get skipped because discordbot was still linked to that process

this fix makes that path actually work by trapping exits and ignoring stale lifecycle messages from old gateway pids

it also cleans up the heartbeat/sequence tracker when the gateway closes, and makes heartbeat stop when its socket owner dies, so reconnects don't leave old heartbeat processes hanging around

tested locally with a small lifecycle repro to confirm old heartbeat processes no longer stay alive after gateway exit

forgot to add docs to the code so i had to make a separate commit for it, sorry dustin, no clean history

