### PR TITLE
Document null spotify fields when a local file is playing

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,13 +81,16 @@ Example response:
     },
     // Below is a custom crafted "spotify" object, which will be null if listening_to_spotify is false
     "spotify": {
+      // null when a local file is playing
       "track_id": "3kdlVcMVsSkbsUy8eQcBjI",
       "timestamps": {
         "start": 1615529820677,
         "end": 1615530068733
       },
       "song": "Let Go",
+      // null when a local file is playing
       "artist": "Ark Patrol; Veronika Redd",
+      // null when a local file is playing
       "album_art_url": "https://i.scdn.co/image/ab67616d0000b27364840995fe43bb2ec73a241d",
       "album": "Let Go"
     },
@@ -145,6 +148,12 @@ Example response:
   }
 }
 ```
+
+#### Spotify local files
+
+When someone plays a local file, Spotify has no catalog track to point at, so Discord leaves `state`, `sync_id` and `assets.large_image` out of the activity. Lanyard still sets `listening_to_spotify` to `true` and still sends the `spotify` object, but `artist`, `track_id` and `album_art_url` are `null` — only `song`, `album` and `timestamps` are guaranteed.
+
+Treat those three fields as nullable. `artist` in particular is a `"; "` separated list when it's present, so splitting it without a null check is a common way to break a page as soon as someone plays a local file.
 
 ### KV
 


### PR DESCRIPTION
The example response in the README shows every `spotify` field populated, which reads as a guarantee. It isn't — when a local file is playing, Spotify has no catalog track to point at, so Discord leaves `state`, `sync_id` and `assets.large_image` out of the activity entirely.

Raw activity Discord sends while a local file plays:

```json
{
  "assets": { "large_text": "ALO" },
  "details": "ALO",
  "id": "spotify:1",
  "name": "Spotify",
  "party": { "id": "spotify:..." },
  "timestamps": { "start": 1784205000542, "end": 1784205089542 },
  "type": 2
}
```

What the API returns for it:

```json
{
  "album": "ALO",
  "album_art_url": null,
  "artist": null,
  "song": "ALO",
  "timestamps": { "start": 1784205000542, "end": 1784205089542 },
  "track_id": null
}
```

`listening_to_spotify` stays `true` and the `spotify` object is still sent, so consumers reasonably assume the fields are populated. `artist` is the sharpest edge: it's a `"; "` separated list when present (as the example shows), and splitting it without a null check throws the moment someone plays a local file.

The behaviour itself is correct — there's no track, artist or CDN art to return — it's just undocumented. #233 fixed this same activity shape crashing Lanyard itself; this documents it so consumers stop running into it from the other side.

Adds `// null when a local file is playing` markers on the three affected fields and a short "Spotify local files" section under the presence example.
