### PR TITLE
fix leaked api key check + crash on cdn proxy paths

### DIFF
--- a/lib/api/routes/quicklinks/discord_cdn.ex
+++ b/lib/api/routes/quicklinks/discord_cdn.ex
@@ -7,12 +7,18 @@ defmodule Lanyard.Api.Quicklinks.DiscordCdn do
   @discord_cdn "https://cdn.discordapp.com"
 
   def proxy_image(conn) do
-    [user_id, file_type] =
+    segment =
       conn.request_path
       |> String.split("/")
       |> Enum.at(1)
-      |> String.split(".")
 
+    case String.split(segment, ".") do
+      [user_id, file_type] -> do_proxy_image(conn, user_id, file_type)
+      _ -> Util.not_found(conn)
+    end
+  end
+
+  defp do_proxy_image(conn, user_id, file_type) do
     presence = Lanyard.Presence.get_pretty_presence(user_id)
 
     case presence do

--- a/lib/bot/commands/set.ex
+++ b/lib/bot/commands/set.ex
@@ -5,7 +5,7 @@ defmodule Lanyard.DiscordBot.Commands.Set do
   def handle([key | value_s], payload) when length(value_s) > 0 do
     value = Enum.join(value_s, " ")
 
-    if ApiKey.contains_api_key?(payload["author"]["id"], key) do
+    if ApiKey.contains_api_key?(payload["author"]["id"], [key, value]) do
       ApiKey.generate_and_send_new(payload["channel_id"], payload["author"]["id"])
     else
       case Lanyard.KV.Interface.set(payload["author"]["id"], key, value) do


### PR DESCRIPTION
.set command was only checking if the key name matched a leaked api key, not the value. so if someone did .set token lnyd_abc123... it would be stored as a plaintext kv value instead of triggering the rotation flow. now it checks both key and value.
cdn avatar proxy would hard crash with a `MatchError` on any path with more than one dot (like /123.456.png), since it assumed the path always splits into two segments. now it just 404s instead of crashing.
nothing changes outside these two spots