### PR TITLE
512 key limit on bulk KV multiset 

### DIFF
--- a/lib/api/routes/v1/users.ex
+++ b/lib/api/routes/v1/users.ex
@@ -44,9 +44,13 @@ defmodule Lanyard.Api.Routes.V1.Users do
             end
           end)
 
-          Lanyard.KV.Interface.multiset(user_id, parsed)
+          case Lanyard.KV.Interface.multiset(user_id, parsed) do
+            {:ok} ->
+              Util.respond(conn, {:ok})
 
-          Util.respond(conn, {:ok})
+            {:error, reason} ->
+              Util.respond(conn, {:error, :kv_validation_failed, reason})
+          end
         rescue
           _e ->
             Util.respond(conn, {:error, :invalid_kv_value, "body must be an object"})

--- a/lib/kv/interface.ex
+++ b/lib/kv/interface.ex
@@ -42,10 +42,24 @@ defmodule Lanyard.KV.Interface do
   end
 
   def multiset(user_id, map) when is_map(map) do
-    Redis.hset("lanyard_kv:#{user_id}", map_to_list(map))
+    kv = get_all(user_id)
+    new_key_count = Map.keys(Map.merge(kv, map)) |> length
 
-    full_kv = get_all(user_id)
-    Presence.sync(user_id, %{kv: Map.merge(full_kv, map)})
+    cond do
+      new_key_count > 511 ->
+        Lanyard.Metrics.Collector.inc(:counter, :lanyard_kv_validation_failures_total, [
+          "key_limit"
+        ])
+
+        {:error, "request would exceed the key limit (512), please delete some keys first"}
+
+      true ->
+        Redis.hset("lanyard_kv:#{user_id}", map_to_list(map))
+
+        full_kv = get_all(user_id)
+        Presence.sync(user_id, %{kv: Map.merge(full_kv, map)})
+        {:ok}
+    end
   end
 
   def del(user_id, key) do


### PR DESCRIPTION
Bulk KV writes /v1/users/:id/kv but never checked the 512 key
limit that single writes already does. This adds the same check to
multiset/2 and returns an error when the limit
would be exceeded :) 
